### PR TITLE
Create mac_install_dev_env.sh

### DIFF
--- a/scripts/mac_install_dev_env.sh
+++ b/scripts/mac_install_dev_env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#install xcode
+xcode-select --install
+
+#install homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+#install docker
+brew install --cask docker


### PR DESCRIPTION
Added bash script for Mac that does the following:
1. install Xcode command line tools
2. install Homebrew
3. use Homebrew to install Docker

I'm assuming macOS 10.14 Mojave or newer.