### PR TITLE
XML to JSON mapping for sections 0, 1, and 2

### DIFF
--- a/JSON_mapping.md
+++ b/JSON_mapping.md
@@ -1,0 +1,190 @@
+This document defines the mapping from XML to JSON so that the JSON can be posted to the FHIR server.
+
+- The "id" field of each question in this JSON form is the "name" field of the corresponding question in the XML form.
+- The "question" field of each question in this JSON form is the "title" field of the corresponding question in the XML form.
+- There are some exceptions to the above two statements which are commented in the JSON below.
+- For questions where the user can check multiple options, the value of "response" should be a list.
+- All dates should be in the format "DD/MM/YYYY" to be consistent with the XML form.
+- The "followup_response" field only needs to be included if there are follow up responses in the form. For example: in "Section 2: Clinical Status"
+of the PDF, if the answer to "Any underlying conditions?" is "No", then the "followup_response" field does not need to be included in the JSON object
+for this question (JSON object for this question is object with "id" value of "Q_38610").
+
+```
+{
+    "preliminary_info": {
+        "description": "Preliminary information",
+        "questions_to_responses": [
+            {
+                "id": "Q_35843",
+                "question": "Date of Reporting to National Health Authority (DD / MM / YYYY)", 
+                "response": <string>
+            },
+            {
+                "id": "Q_35872",
+                "question": "Reporting Country", 
+                "response": <string>
+            },
+            {
+                "id": "Q_35849",
+                "question": "Why Tested for COVID-19",
+                "response": <list of string>,
+                "followup_response": [
+                    {
+                        "id": "LI_35963",
+                        "question": "None of the above (explain)",
+                        "response": <string>
+                    }
+                ]
+            }
+        ]
+    },
+    "patient_info": {
+        "description": "Patient information",
+        "questions_to_responses": [
+            {
+                "id": "Q_37326",
+                "question": "Unique Case Identifier (used in country)", 
+                "response": <string>
+            },
+            {
+                "id": "Q_35972",
+                "question": "Age", 
+                "response": <int>,
+                "followup_response": [
+                    {                               // Note that this object has no corresponding place in the XML form, i.e. there is no question in the XML form with 
+                                                    // "name" having value "Q_35972_Units" and "title" having value "Age Units". The reason this object has to be created
+                                                    // is because in the PDF form there are three different places to insert the age depending on if the person is <1 month 
+                                                    // old, <1 year old or >=1 year old. It doesn't make sense for this JSON to differentiate the three places as done in the 
+                                                    // XML form. So this object will represent the units of the age (days, months or years).
+                        "id": "Q_35972_Units",
+                        "question": "Age Units",
+                        "response": <string>        // value for "response" should be one of the following: {"days", "months", "years"}
+                    }
+                ]
+            },
+            {
+                "id": "Q_35978",
+                "question": "Sex at Birth", 
+                "response": <string>
+            },
+            {
+                "id": "Q_35932",
+                "question": "Place Where the Case Was Diagnosed (Country)",
+                "response": <string>,
+                "followup_response": [
+                    {
+                        "id": "Q_35935",
+                        "question": "Admin Level 1 (Province)",
+                        "response": <string>
+                    }
+                ]
+            },
+            {
+                "id": "Q_35981",
+                "question": "Case Usual Place of Residency (Country)",
+                "response": <string>
+            }
+        ]
+    },
+    "clinical_status": {
+        "description": "Clinical status",
+        "questions_to_responses": [
+            {
+                "id": "Q_35943"
+                "question": "Date of First Laboratory Confirmation Test (DD / MM / YYYY)", 
+                "response": <string>
+            },
+            {
+                "id": "Q_35995"
+                "question": "Symptoms or Signs at Time of Specimen Collection that Resulted in First Laboratory Confirmation", 
+                "response": <string>,
+                "followup_response": [
+                    {
+                        "id": "Q_37429",
+                        "question": "Specify Date of Onset of Symptoms (DD / MM / YYYY)",
+                        "response": <string>
+                    }
+                ]
+            },
+            {
+                "id": "Q_38610",
+                "question": "Underlying Conditions and Comorbidity",
+                "response": <string>,
+                "followup_response": [
+                    {                               // Note that this object doesn't have a "question" field because the corresponding question in the XML form doesn't have
+                                                    // a "title" field
+                        "id": "Q_35960",
+                        "response": <list of string>
+                    }
+                ]
+            },
+            {
+                "id": "Q_36015",
+                "question": "Admission to Hospital",
+                "response": <string>,
+                "followup_response": [
+                    {
+                        "id": "Q_39750",
+                        "question": "Specify Date of First Admission (DD / MM / YYYY)",
+                        "response": <string>
+                    },
+                    {
+                        "id": "Q_36845",
+                        "question": "Did the Case Receive Care in an Intensive Care Unit (ICU)?",
+                        "response": <string>
+                    },
+                    {
+                        "id": "Q_36862",
+                        "question": "Did the Case Receive Ventilation?",
+                        "response": <string>
+                    },
+                    {
+                        "id": "Q_36032",
+                        "question": "Did the Case Receive Extracorporeal Membrane Oxygenation?",
+                        "response": <string>
+                    }
+                ]
+            },
+            {
+                "id": "Q_36839",
+                "question": "Is Case in Isolation with Infection Control Practice in Place?",
+                "response": <string>,
+                "followup_response": [
+                    {
+                        "id": "Q_41854",
+                        "question: "Specify Date of Isolation (DD / MM / YYYY)",
+                        "response": <string>
+                    }
+                ]
+            }
+        ]
+    },
+    "exposure_risk": {
+        "description": "",
+        "questions_to_responses": [
+            {
+                "id": ""
+                "question": "", 
+                "response": "",
+                "followup_response": [
+                    {
+                        "id": ""
+                        "question": ""
+                        "response": ""
+                    }
+                ]
+            }
+        ]
+    },
+    "outcome": {
+        "description": "",
+        "questions_to_responses": [
+            {
+                "id": ""
+                "question": "", 
+                "response": ""
+            }
+        ]
+    }
+}
+```

--- a/JSON_mapping.md
+++ b/JSON_mapping.md
@@ -2,7 +2,7 @@ This document defines the mapping from XML to JSON so that the JSON can be poste
 
 - The "id" field of each question in this JSON form is the "name" field of the corresponding question in the XML form.
 - The "question" field of each question in this JSON form is the "title" field of the corresponding question in the XML form.
-- There are some exceptions to the above two statements which are commented in the JSON below.
+- There may be some exceptions to the above two statements which will be commented in the JSON below.
 - For questions where the user can check multiple options, the value of "response" should be a list.
 - All dates should be in the format "DD/MM/YYYY" to be consistent with the XML form.
 - The "followup_response" field only needs to be included if there are follow up responses in the form. For example: in "Section 2: Clinical Status"
@@ -49,18 +49,11 @@ for this question (JSON object for this question is object with "id" value of "Q
             {
                 "id": "Q_35972",
                 "question": "Age", 
-                "response": <int>,
-                "followup_response": [
-                    {                               // Note that this object has no corresponding place in the XML form, i.e. there is no question in the XML form with 
-                                                    // "name" having value "Q_35972_Units" and "title" having value "Age Units". The reason this object has to be created
-                                                    // is because in the PDF form there are three different places to insert the age depending on if the person is <1 month 
-                                                    // old, <1 year old or >=1 year old. It doesn't make sense for this JSON to differentiate the three places as done in the 
-                                                    // XML form. So this object will represent the units of the age (days, months or years).
-                        "id": "Q_35972_Units",
-                        "question": "Age Units",
-                        "response": <string>        // value for "response" should be one of the following: {"days", "months", "years"}
-                    }
-                ]
+                "response": {
+                    "days": <int>,
+                    "months": <int>,
+                    "years": <int>
+                }
             },
             {
                 "id": "Q_35978",


### PR DESCRIPTION
@SoniaZaldana I have added a file that specifies the XML to JSON mapping for sections 0, 1 and 2. 

Three important things I want to point out:
1. The `id` field of each question in this JSON form is the `name` field of the corresponding question in the XML form (https://github.com/SoniaZaldana/covid19-reporting/blob/jsonConversion/src/form.json). It is NOT the `ID` field in the XML form. The reason I did this is because the values for `ID` in the XML form seem to be floats and it seems to make more sense to use the values for `name` in the XML form since they are shorter and alphanumeric.
2. The `question` field of each question in this JSON form is the `title` field of the corresponding question in the XML form, NOT the PDF (https://github.com/IHE-SDC-WG/SDC-Sample-XML-Files/blob/master/COVID%2019/2019-covid-crf-v6.pdf). The questions in the PDF and the value in the `title` field of the XML form aren't always equivalent, so I decided to go with the value in the `title` field when choosing what to write in the `question` field for the JSON.
3. There are two places in the JSON that deviate from the structure as we discussed in the meeting and I have commented in the JSON where the two places are and why I did it that way.

One thing that I did that I'm unsure of:
In the JSON mapping, under `preliminary_info`, I created this object:
```
{
                "id": "Q_35849",
                "question": "Why Tested for COVID-19",
                "response": <list of string>,
                "followup_response": [
                    {
                        "id": "LI_35963",
                        "question": "None of the above (explain)",
                        "response": <string>
                    }
                ]
            }
```

I'm not sure if there should be a `followup_response` here. The reason I added it in is because if you look in the PDF (https://github.com/IHE-SDC-WG/SDC-Sample-XML-Files/blob/master/COVID%2019/2019-covid-crf-v6.pdf), at the top of the page where it says "Why tested for COVID-19:", one of the options is "If none of the above, please explain". I'm not sure if the response to this option should go as a followup response or be a part of the intial `response`. What do you think?

Keeping the above things I mentioned in mind, you should be good to start on mapping your sections! Let me know if you have any questions/need clarification! 