### PR TITLE
Implemented POST request to HAPI FHIR server

### DIFF
--- a/JSON_mapping.md
+++ b/JSON_mapping.md
@@ -205,11 +205,6 @@ for this question (JSON object for this question is object with "id" value of "Q
                 "response": <string>, 
                 "followup_response": [
                     {
-                        "id": "Q_36917"
-                        "question": "Please List Unique Identifiers of All Probable or Confirmed Cases", 
-                        "response": <string>
-                    }, 
-                    {
                         "id": "Q_37375"
                         "question": "Please Explain Contact Setting", 
                         "response": <string>
@@ -283,33 +278,28 @@ for this question (JSON object for this question is object with "id" value of "Q
             },
             {
                 "id": "Q_37025", 
-                "question": "Health Outcome"", 
+                "question": "Health Outcome", 
                 "response": <string>, 
-                "followup_response": []
             }, 
             {
                 "id": "Q_37412", 
                 "question": "Date of Release or Death (DD / MM / YYYY)", 
                 "response": <string>, 
-                "followup_response": []
             },
             {
                 "id": "Q_37420", 
                 "question": "Specify Date of Last Laboratory Test (DD / MM / YYYY)", 
                 "response": <string>, 
-                "followup_response": []
             }, 
             {
                 "id": "Q_39438", 
                 "question": "Results of Last Test", 
                 "response": <string>, 
-                "followup_response": []
             }, 
             {
                 "id": "Q_39564", 
                 "question": "Total Number of Contacts Followed for this Case", 
                 "response": <string>, 
-                "followup_response": []
             }
         ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
+        "axios": "^0.24.0",
         "bootstrap": "^5.1.1",
         "react": "^17.0.2",
         "react-bootstrap": "^2.0.0-rc.1",
@@ -4612,6 +4613,14 @@
       "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/axobject-query": {
@@ -25037,6 +25046,14 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
       "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA=="
+    },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "axios": "^0.24.0",
     "bootstrap": "^5.1.1",
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.0-rc.1",


### PR DESCRIPTION
Major changes:
- Implemented POST request to the `/DocumentReference` endpoint of the HAPI FHIR server
- Added axios library in order to make the POST request
- Modified the UI slightly to show a message underneath the Submit button to indicate whether the data was successfully POSTed to the FHIR server