### PR TITLE
Updating acceptance criteria for tests

### DIFF
--- a/A3.md
+++ b/A3.md
@@ -16,7 +16,7 @@ For the past deliverable, we accomplished the following:
 
 3. How plans were adjusted, in light of that information, including goals or features that were dropped 
 * We have adjusted our plans to account for the need to refactor our form validation, so that we can include sensible test coverage for this feature. 
-* Additionally, we decided to engage in conversations with the client in how to better validate that our web app is correctly interacting with the FHIR server. Though this is discussed in more depth below, the main idea is that we need tests to ensure we get the correct response codes when interacting with the FHIR server and that we can validate our covid-19 form is available in the server after we post it. 
+* Additionally, we decided to engage in conversations with the client in how to better validate that our web app is correctly interacting with the FHIR server. Though this is discussed in more depth below, the main idea is that we need tests to ensure we get the correct response codes when interacting with the FHIR server. 
 * No features were dropped in light of the goals we missed. 
 
 ## Overview of Project 
@@ -45,7 +45,7 @@ Based on discussions with our client, the acceptance criteria for this feature i
 The [/DocumentReference](https://www.hl7.org/fhir/documentreference.html#resource) endpoint provides metadata about any document stored in the FHIR server allowing it to be discovered and managed by a healthcare system. The purpose of this feature is allowing Covid-19 reporting forms to be easily managed by various healthcare agents. 
 
 ### Acceptance Criteria & How We Met It 
-The acceptance criteria for this feature, as specified by the client, consists of tests verifying we get the expected response code when posting our document. Additionally, we need to test sending a GET request to the endpoint, to ensure we can successfully retrieve the document we posted to the server.  We have fulfilled this verification criteria by providing unit tests for both these scenarios in our code base. 
+The acceptance criteria for this feature, as specified by the client, consists of tests verifying we get the expected response code when posting our document. This includes verifying a successful message with a valid attachment versus an error message with an invalid attachment. We have fulfilled this verification criteria by providing unit tests for both these scenarios in our code base. Note that we opted out of using a GET request to validate we had posted our attachment to the server, as we are mocking the POST requests so that we are not actually posting to the HAPI FHIR server every time we run our tests. 
 
 ## Project Rationale and Extensibility 
 Early in our discussions with the client, we chose to use the `/DocumentReference` endpoint for the FHIR server, as opposed to using a `/QuestionnaireResponse` endpoint. The reason behind this is because mapping the data elements in the form does not provide a 1:1 match. We made this decision following advice from the client, based on their own experience trying to work with the `/QuestionnaireResponse` endpoint. 

--- a/meeting_minutes/November26.md
+++ b/meeting_minutes/November26.md
@@ -5,9 +5,9 @@ Hi Alex,
 As we are approaching our final deliverable, we wanted to touch base with you one last time to ensure we are meeting the expectations for our project. We have drafted this acceptance criteria for our project and were wondering if you could provide us feedback. 
 
 Find below a list of the features and the acceptance criteria: 
-A full fledged user interface that allows users to input their responses to the Covid-19 reporting form, as specified by the XML you provided us at the beginning of the semester. The acceptance criteria consists of verifying each of the elements in the XML form are included in the UI. 
-Form validation for the responses to the form. The acceptance criteria consists of various unit tests to ensure each field receives sensible data i.e. names shouldn’t include numbers or symbols, dates should follow a specific format, etc. 
-The ability to POST the responses to the form as an attachment to the /DocumentReference endpoint in the HAPI FHIR server. The acceptance criteria consists of tests verifying we get the expected response code when POSTing as well as GET tests to verify our document was correctly sent to the server. 
+1. A full fledged user interface that allows users to input their responses to the Covid-19 reporting form, as specified by the XML you provided us at the beginning of the semester. The acceptance criteria consists of verifying each of the elements in the XML form are included in the UI. 
+2. Form validation for the responses to the form. The acceptance criteria consists of various unit tests to ensure each field receives sensible data i.e. names shouldn’t include numbers or symbols, dates should follow a specific format, etc. 
+3. The ability to POST the responses to the form as an attachment to the /DocumentReference endpoint in the HAPI FHIR server. The acceptance criteria consists of tests verifying we get the expected response code when POSTing.
 
 ## Client Response
 He said excellent job, no feedback at the moment. 


### PR DESCRIPTION
* Based on choosing to mock the POST requests in our tests, we can't actually use GET requests as part of our test. 